### PR TITLE
Add simple CI pipeline for building and testing the changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, master ]
 
 jobs:
-  build-test:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -54,11 +54,6 @@ jobs:
       - name: Build application
         run: |
           sbt frontendInstallDependencies build
-
-      # Run tests
-      - name: Run tests
-        run: |
-          sbt test
 
       # Upload build artifact (optional but useful)
       - name: Upload server package


### PR DESCRIPTION
This PR adds a simple workflow to build and test vdjdb-web. This branch does not contain build and publishing to DockerHub. This will come in a different PR. 